### PR TITLE
INTSCALA-50 - spring-integration compilable in scala 2.10 

### DIFF
--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/AggregatorEndpointDsl.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/AggregatorEndpointDsl.scala
@@ -232,6 +232,6 @@ private[dsl] case class Aggregator(override val name: String = "$aggr_" + UUID.r
 private class ReleaseFunctionWrapper[T](val releaseFunction: Function1[Iterable[T], Boolean]) extends Function1[java.util.Collection[T], Boolean] {
 
   def apply(messages: java.util.Collection[T]): Boolean = {
-    releaseFunction(JavaConversions.asIterable[T](messages))
+    releaseFunction(JavaConversions.collectionAsScalaIterable[T](messages))
   }
 }

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/SingleMessageScalaFunctionWrapper.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/SingleMessageScalaFunctionWrapper.scala
@@ -30,7 +30,7 @@ private[dsl] class SingleMessageScalaFunctionWrapper[I,F](val f: Function1[I, F]
       if (classOf[Iterable[I]].isAssignableFrom(iErasure)) {
         message match {
           case javaCollection: java.util.Collection[I] => {
-            f(JavaConversions.asIterable(javaCollection).asInstanceOf[I])
+            f(JavaConversions.collectionAsScalaIterable(javaCollection).asInstanceOf[I])
           }
           case _ => f(message)
         }

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/utils/DslUtils.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/utils/DslUtils.scala
@@ -77,7 +77,7 @@ object DslUtils {
 
   private[dsl] def setAdditionalAttributes(element: Element, attributeMap: Map[String, Any], compositionInitFunction: Function2[BaseIntegrationComposition, AbstractChannel, Unit]): Unit = {
     attributeMap.keys.foreach { key: String =>
-      val propertyValue: Any = attributeMap.get(key).elements.next()
+      val propertyValue: Any = attributeMap.get(key).productIterator.next()
       val attributeName = Conventions.propertyNameToAttributeName(key)
       val propertyValueToSet =
         if (propertyValue != null) {


### PR DESCRIPTION
Currently the project does not compile using scala compiler 2.10 (M7 as of today) due to removal of deprecated methods in scala library classes.
