### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ The Spring Integration Extensions Framework is released under version 2.0 of the
 [Pull requests]: https://help.github.com/send-pull-requests
 [contributor guidelines]: https://github.com/SpringSource/spring-integration/wiki/Contributor-guidelines
 [administrator guidelines]: https://github.com/SpringSource/spring-integration/wiki/Administrator-Guidelines
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/AggregatorEndpointDsl.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/AggregatorEndpointDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/BaseIntegrationComposition.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/BaseIntegrationComposition.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/EnricherEndpointDsl.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/EnricherEndpointDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/FilterEndpointDsl.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/FilterEndpointDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/FunctionInvoker.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/FunctionInvoker.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/InboundChannelAdapterConfig.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/InboundChannelAdapterConfig.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/InboundChannelAdapterDsl.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/InboundChannelAdapterDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/IntegrationContext.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/IntegrationContext.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/MessageChannel.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/MessageChannel.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/ParsedMessageScalaFunctionWrapper.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/ParsedMessageScalaFunctionWrapper.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/Poller.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/Poller.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/RouterEndpointDsl.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/RouterEndpointDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/ServiceActivatingEndpointDsl.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/ServiceActivatingEndpointDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/SingleMessageScalaFunctionWrapper.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/SingleMessageScalaFunctionWrapper.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/SplitterEndpointDsl.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/SplitterEndpointDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/TransformingEndpointDsl.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/TransformingEndpointDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/utils/DslUtils.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/utils/DslUtils.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/utils/IntegrationDomTreeBuilder.scala
+++ b/spring-integration-dsl-scala-core/src/main/scala/org/springframework/integration/dsl/utils/IntegrationDomTreeBuilder.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/demo/DslUsageDemoTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/demo/DslUsageDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/demo/OrderProcessingDemoTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/demo/OrderProcessingDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/DSLBootstrapTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/DSLBootstrapTests.scala
@@ -5,7 +5,7 @@
 // * you may not use this file except in compliance with the License.
 // * You may obtain a copy of the License at
 // *
-// *      http://www.apache.org/licenses/LICENSE-2.0
+// *      https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * Unless required by applicable law or agreed to in writing, software
 // * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/EnricherTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/EnricherTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/InboundChannelAdapterTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/InboundChannelAdapterTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/IntegrationDomTreeBuilderTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/IntegrationDomTreeBuilderTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageAggregatorTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageAggregatorTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageChannelTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageChannelTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageEndpointTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageEndpointTests.scala
@@ -5,7 +5,7 @@
 // * you may not use this file except in compliance with the License.
 // * You may obtain a copy of the License at
 // *
-// *      http://www.apache.org/licenses/LICENSE-2.0
+// *      https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * Unless required by applicable law or agreed to in writing, software
 // * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageFilterTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageFilterTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageRouterTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/MessageRouterTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/ParentApplicationContextTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/ParentApplicationContextTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/PollerTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/PollerTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/ScalaDslFlowFactory.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/ScalaDslFlowFactory.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/ServiceActivatorTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/ServiceActivatorTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/TransformerTests.scala
+++ b/spring-integration-dsl-scala-core/src/test/scala/org/springframework/integration/dsl/TransformerTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-file/src/main/scala/org/springframework/integration/dsl/FileDsl.scala
+++ b/spring-integration-dsl-scala-file/src/main/scala/org/springframework/integration/dsl/FileDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-file/src/main/scala/org/springframework/integration/dsl/FileInboundDsl.scala
+++ b/spring-integration-dsl-scala-file/src/main/scala/org/springframework/integration/dsl/FileInboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-file/src/main/scala/org/springframework/integration/dsl/FileOutboundDsl.scala
+++ b/spring-integration-dsl-scala-file/src/main/scala/org/springframework/integration/dsl/FileOutboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-file/src/test/scala/demo/DslUsageDemoTests.scala
+++ b/spring-integration-dsl-scala-file/src/test/scala/demo/DslUsageDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-ftp/src/main/scala/org/springframework/integration/dsl/FtpDsl.scala
+++ b/spring-integration-dsl-scala-ftp/src/main/scala/org/springframework/integration/dsl/FtpDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-ftp/src/main/scala/org/springframework/integration/dsl/FtpInboundDsl.scala
+++ b/spring-integration-dsl-scala-ftp/src/main/scala/org/springframework/integration/dsl/FtpInboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-ftp/src/main/scala/org/springframework/integration/dsl/FtpOutboundDsl.scala
+++ b/spring-integration-dsl-scala-ftp/src/main/scala/org/springframework/integration/dsl/FtpOutboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-ftp/src/test/scala/demo/DslUsageDemoTests.scala
+++ b/spring-integration-dsl-scala-ftp/src/test/scala/demo/DslUsageDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-ftp/src/test/scala/demo/TestSessionFactory.java
+++ b/spring-integration-dsl-scala-ftp/src/test/scala/demo/TestSessionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-gemfire/src/main/scala/org/springframework/integration/dsl/GemfireDsl.scala
+++ b/spring-integration-dsl-scala-gemfire/src/main/scala/org/springframework/integration/dsl/GemfireDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-gemfire/src/main/scala/org/springframework/integration/dsl/GemfireInboundConfig.scala
+++ b/spring-integration-dsl-scala-gemfire/src/main/scala/org/springframework/integration/dsl/GemfireInboundConfig.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-gemfire/src/main/scala/org/springframework/integration/dsl/GemfireOutboundConfig.scala
+++ b/spring-integration-dsl-scala-gemfire/src/main/scala/org/springframework/integration/dsl/GemfireOutboundConfig.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-gemfire/src/test/scala/demo/DslUsageDemoTests.scala
+++ b/spring-integration-dsl-scala-gemfire/src/test/scala/demo/DslUsageDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-http/src/main/scala/org/springframework/integration/dsl/HttpOutboundGatewayDsl.scala
+++ b/spring-integration-dsl-scala-http/src/main/scala/org/springframework/integration/dsl/HttpOutboundGatewayDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-http/src/test/scala/demo/DslUsageDemoTests.scala
+++ b/spring-integration-dsl-scala-http/src/test/scala/demo/DslUsageDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-integration-demos/src/test/scala/demo/IntegrationDemoUtils.scala
+++ b/spring-integration-dsl-scala-integration-demos/src/test/scala/demo/IntegrationDemoUtils.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-integration-demos/src/test/scala/demo/JmsToFileDemoTests.scala
+++ b/spring-integration-dsl-scala-integration-demos/src/test/scala/demo/JmsToFileDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/C24Demo.scala
+++ b/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/C24Demo.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24DemoUtils.java
+++ b/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24DemoUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24FixUnmarshallingTransformer.java
+++ b/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24FixUnmarshallingTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24Iso20022UnmarshallingTransformer.java
+++ b/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24Iso20022UnmarshallingTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24Object.java
+++ b/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24Object.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24SwiftUnmarshallingTransformer.java
+++ b/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24SwiftUnmarshallingTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24Validator.java
+++ b/spring-integration-dsl-scala-integration-demos/src/test/scala/scala/c24/demo/java/C24Validator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jdbc/src/main/scala/org/springframework/integration/dsl/JdbcDsl.scala
+++ b/spring-integration-dsl-scala-jdbc/src/main/scala/org/springframework/integration/dsl/JdbcDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jdbc/src/main/scala/org/springframework/integration/dsl/JdbcInboundDsl.scala
+++ b/spring-integration-dsl-scala-jdbc/src/main/scala/org/springframework/integration/dsl/JdbcInboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jdbc/src/main/scala/org/springframework/integration/dsl/JdbcOutboundDsl.scala
+++ b/spring-integration-dsl-scala-jdbc/src/main/scala/org/springframework/integration/dsl/JdbcOutboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jdbc/src/test/scala/demo/DslUsageDemoTests.scala
+++ b/spring-integration-dsl-scala-jdbc/src/test/scala/demo/DslUsageDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jdbc/src/test/scala/demo/JdbcPollingChannelAdapterTests.scala
+++ b/spring-integration-dsl-scala-jdbc/src/test/scala/demo/JdbcPollingChannelAdapterTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jms/src/main/scala/org/springframework/integration/dsl/JmsDsl.scala
+++ b/spring-integration-dsl-scala-jms/src/main/scala/org/springframework/integration/dsl/JmsDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jms/src/main/scala/org/springframework/integration/dsl/JmsInboundDsl.scala
+++ b/spring-integration-dsl-scala-jms/src/main/scala/org/springframework/integration/dsl/JmsInboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jms/src/main/scala/org/springframework/integration/dsl/JmsOutboundDsl.scala
+++ b/spring-integration-dsl-scala-jms/src/main/scala/org/springframework/integration/dsl/JmsOutboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jms/src/test/scala/demo/DslUsageDemoTests.scala
+++ b/spring-integration-dsl-scala-jms/src/test/scala/demo/DslUsageDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-jms/src/test/scala/org/springframework/integration/dsl/utils/JmsDslTestUtils.scala
+++ b/spring-integration-dsl-scala-jms/src/test/scala/org/springframework/integration/dsl/utils/JmsDslTestUtils.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-sftp/src/main/scala/org/springframework/integration/dsl/SftpDsl.scala
+++ b/spring-integration-dsl-scala-sftp/src/main/scala/org/springframework/integration/dsl/SftpDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-sftp/src/main/scala/org/springframework/integration/dsl/SftpInboundDsl.scala
+++ b/spring-integration-dsl-scala-sftp/src/main/scala/org/springframework/integration/dsl/SftpInboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-sftp/src/main/scala/org/springframework/integration/dsl/SftpOutboundDsl.scala
+++ b/spring-integration-dsl-scala-sftp/src/main/scala/org/springframework/integration/dsl/SftpOutboundDsl.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-sftp/src/test/scala/demo/DslUsageDemoTests.scala
+++ b/spring-integration-dsl-scala-sftp/src/test/scala/demo/DslUsageDemoTests.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-integration-dsl-scala-sftp/src/test/scala/demo/TestSessionFactory.java
+++ b/spring-integration-dsl-scala-sftp/src/test/scala/demo/TestSessionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 74 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).